### PR TITLE
feat: json output and manual remapping of secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-output/.env
+output/*.env
 output/*.tfvars
+output/*.json
 secrets.y*ml
 dist/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ See `racoon help` or ` racoon --help` for all available commands
 ## Outputs
 
 - dotenv
-- Terraform tfvars
+- json
+- tfvars (Terraform)
 
 ## Examples
 
@@ -71,10 +72,11 @@ outputs:
 - [ ] Tagging of external resources
 - [ ] Context support (dev / production / cicd / localdev etc)
 - [ ] Key format for Parameter Store
+- [x] Remapping support for outputs (PaymetApiKey -> Payment\_\_ApiKey)
 - [ ] Generators for providing generated values when seeding a secret
 - [ ] Listing secrets in a given context
 - [ ] Deleting a secret from the store
-- [ ] Json output format
+- [x] Json output format
 - [ ] Shell (bash/zsh/sh) output format
 - [ ] Certificate output format
 - [ ] Kubernetes secret output format

--- a/internal/command/export.go
+++ b/internal/command/export.go
@@ -85,7 +85,7 @@ func Export(ctx config.AppContext) *cli.Command {
 				}
 
 				file := os.Stdout
-				if path != "-" {
+				if path != "" && path != "-" {
 					if file, err = os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644); err != nil {
 						return fmt.Errorf("failed to open file for writing, %v", err)
 					}
@@ -98,11 +98,15 @@ func Export(ctx config.AppContext) *cli.Command {
 				switch o.Type {
 				case config.OutputTypeDotenv:
 					ctx.Log.Infof("exporting secrets as dotenv ( path=%s )", path)
-					output.Dotenv(w, m, values)
+					output.Dotenv(w, m, o.Map, values)
 					break
 				case config.OutputTypeTfvars:
 					ctx.Log.Infof("exporting secrets as tfvars ( path=%s )", path)
-					output.Tfvars(w, m, values)
+					output.Tfvars(w, m, o.Map, values)
+					break
+				case config.OutputTypeJson:
+					ctx.Log.Infof("exporting secrets as json ( path=%s )", path)
+					output.Json(w, m, o.Map, values)
 					break
 				default:
 					panic(fmt.Errorf("unsupported output type %s", o.Type))

--- a/internal/config/manifest.go
+++ b/internal/config/manifest.go
@@ -12,6 +12,7 @@ import (
 const (
 	OutputTypeDotenv OutputType = "dotenv"
 	OutputTypeTfvars OutputType = "tfvars"
+	OutputTypeJson   OutputType = "json"
 
 	StoreTypeAwsParameterStore string = "awsParameterStore"
 )
@@ -79,8 +80,9 @@ type ValueFromAwsParameterStoreConfig struct {
 }
 
 type OutputConfig struct {
-	Type OutputType `yaml:"type"`
-	Path string     `yaml:"path"`
+	Type OutputType        `yaml:"type"`
+	Path string            `yaml:"path"`
+	Map  map[string]string `yaml:"map"`
 }
 
 type OutputType string

--- a/internal/output/conventions.go
+++ b/internal/output/conventions.go
@@ -1,0 +1,25 @@
+package output
+
+import (
+	"strings"
+
+	"github.com/fatih/camelcase"
+)
+
+func CamelCaseSplitToUpperJoinByUnderscore(name string) (key string) {
+	parts := camelcase.Split(name)
+	for i, part := range parts {
+		parts[i] = strings.ToUpper(part)
+	}
+	key = strings.Join(parts, "_")
+	return
+}
+
+func CamelCaseSplitToLowerJoinByUnderscore(name string) (key string) {
+	parts := camelcase.Split(name)
+	for i, part := range parts {
+		parts[i] = strings.ToLower(part)
+	}
+	key = strings.Join(parts, "_")
+	return
+}

--- a/internal/output/dotenv.go
+++ b/internal/output/dotenv.go
@@ -6,17 +6,17 @@ import (
 	"strings"
 
 	"github.com/dotnetmentor/racoon/internal/config"
-
-	"github.com/fatih/camelcase"
 )
 
-func Dotenv(w io.Writer, m config.Manifest, values map[string]string) {
+func Dotenv(w io.Writer, m config.Manifest, keys map[string]string, values map[string]string) {
 	for _, s := range m.Secrets {
-		parts := camelcase.Split(s.Name)
-		for i, part := range parts {
-			parts[i] = strings.ToUpper(part)
+		var key string
+		if remapped, ok := keys[s.Name]; ok && remapped != "" {
+			key = remapped
+		} else {
+			key = CamelCaseSplitToUpperJoinByUnderscore(s.Name)
 		}
-		key := strings.Join(parts, "_")
+
 		value := strings.TrimSuffix(values[s.Name], "\n")
 		w.Write([]byte(fmt.Sprintf("%s=\"%s\"\n", key, value)))
 	}

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -1,23 +1,25 @@
 package output
 
 import (
-	"fmt"
+	"encoding/json"
 	"io"
 	"strings"
 
 	"github.com/dotnetmentor/racoon/internal/config"
 )
 
-func Tfvars(w io.Writer, m config.Manifest, keys map[string]string, values map[string]string) {
+func Json(w io.Writer, m config.Manifest, keys map[string]string, values map[string]string) {
+	jo := map[string]string{}
 	for _, s := range m.Secrets {
 		var key string
 		if remapped, ok := keys[s.Name]; ok && remapped != "" {
 			key = remapped
 		} else {
-			key = CamelCaseSplitToLowerJoinByUnderscore(s.Name)
+			key = s.Name
 		}
 
 		value := strings.TrimSuffix(values[s.Name], "\n")
-		w.Write([]byte(fmt.Sprintf("%s = \"%s\"\n", key, value)))
+		jo[key] = value
 	}
+	json.NewEncoder(w).Encode(jo)
 }


### PR DESCRIPTION
```
secrets:
  - name: TwilioApiKey
    description: MongoDB Connection string
    default: some value from another store
outputs:
  - type: dotenv
    path: output/.env
    map:
      TwilioApiKey: Twilio__ApiKey
```
This is to support creating env-files that can be used by dotnet core configuration builders. If you don't specify a property in the map, default output mapping conventions apply.

This also adds support for a json output type:
```
secrets:
  - name: TwilioApiKey
    description: MongoDB Connection string
    default: some value from another store
outputs:
  - type: json
    path: output/secrets.json
```

Produces something similar to:
```
{"TwilioApiKey": "some value from another store"}
```