### PR TITLE
feat: adds support for includes and excludes when using the export command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ racoon export                                   # exports all secrets using the 
 racoon export --output direnv                   # exports all secrets using the direnv output defined in the manifest file
 racoon export --output direnv --path dot.env    # exports all secrets using the direnv output to the specified path
 racoon export -o direnv -p -                    # exports all secrets using the direnv output, writing the result to stdout
+racoon export -o direnv --include Secret1       # export Secret1 using the direnv output
+racoon export -o direnv --exclude Secret1       # export all secrets but Secret1 using the direnv output
 ```
 
 ### secrets.y\*ml
@@ -89,7 +91,8 @@ outputs:
 - [ ] Move command for moving secrets in the store
 - [ ] Init command for creating the manifest file
 - [ ] Cleaner handling of errors (less panic, more logging and exit codes)
-- [ ] Ability to select secrets for export (racoon export -s Secret1 -s Secret2)
+- [x] Ability to select secrets for export using flags (racoon export --include||--exclude Secret1)
+- [x] Ability to select secrets for export using output config (include:[] exclude:[])
 - [ ] Conditional sync for faster exports (export based on hash sum for context)
 
 ## Development

--- a/internal/command/export.go
+++ b/internal/command/export.go
@@ -108,6 +108,17 @@ func Export(ctx config.AppContext) *cli.Command {
 					continue
 				}
 
+				filtered := []string{}
+				for _, s := range secrets {
+					if len(o.Exclude) > 0 && utils.StringSliceContains(o.Exclude, s) {
+						continue
+					}
+					if len(o.Include) > 0 && !utils.StringSliceContains(o.Include, s) {
+						continue
+					}
+					filtered = append(filtered, s)
+				}
+
 				file := os.Stdout
 				if path != "" && path != "-" {
 					if file, err = os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644); err != nil {
@@ -122,15 +133,15 @@ func Export(ctx config.AppContext) *cli.Command {
 				switch o.Type {
 				case config.OutputTypeDotenv:
 					ctx.Log.Infof("exporting secrets as dotenv ( path=%s )", path)
-					output.Dotenv(w, secrets, o.Map, values)
+					output.Dotenv(w, filtered, o.Map, values)
 					break
 				case config.OutputTypeTfvars:
 					ctx.Log.Infof("exporting secrets as tfvars ( path=%s )", path)
-					output.Tfvars(w, secrets, o.Map, values)
+					output.Tfvars(w, filtered, o.Map, values)
 					break
 				case config.OutputTypeJson:
 					ctx.Log.Infof("exporting secrets as json ( path=%s )", path)
-					output.Json(w, secrets, o.Map, values)
+					output.Json(w, filtered, o.Map, values)
 					break
 				default:
 					panic(fmt.Errorf("unsupported output type %s", o.Type))

--- a/internal/command/export.go
+++ b/internal/command/export.go
@@ -33,9 +33,14 @@ func Export(ctx config.AppContext) *cli.Command {
 				Usage:   "export a single output to the specified path",
 			},
 			&cli.StringSliceFlag{
-				Name:    "select",
-				Aliases: []string{"s"},
-				Usage:   "export selected secret",
+				Name:    "include",
+				Aliases: []string{"i"},
+				Usage:   "include secret in export",
+			},
+			&cli.StringSliceFlag{
+				Name:    "exclude",
+				Aliases: []string{"e"},
+				Usage:   "exclude secret from export",
 			},
 		},
 		Action: func(c *cli.Context) error {
@@ -51,15 +56,20 @@ func Export(ctx config.AppContext) *cli.Command {
 				return err
 			}
 
-			selection := c.StringSlice("select")
+			includes := c.StringSlice("include")
+			excludes := c.StringSlice("exclude")
 
 			// read from store
 			secrets := []string{}
 			values := map[string]string{}
 			for _, s := range m.Secrets {
-				if len(selection) > 0 && !utils.StringSliceContains(selection, s.Name) {
+				if len(excludes) > 0 && utils.StringSliceContains(excludes, s.Name) {
 					continue
 				}
+				if len(includes) > 0 && !utils.StringSliceContains(includes, s.Name) {
+					continue
+				}
+
 				secrets = append(secrets, s.Name)
 
 				if s.Default != nil {

--- a/internal/config/manifest.go
+++ b/internal/config/manifest.go
@@ -80,9 +80,11 @@ type ValueFromAwsParameterStoreConfig struct {
 }
 
 type OutputConfig struct {
-	Type OutputType        `yaml:"type"`
-	Path string            `yaml:"path"`
-	Map  map[string]string `yaml:"map"`
+	Type    OutputType        `yaml:"type"`
+	Path    string            `yaml:"path"`
+	Map     map[string]string `yaml:"map"`
+	Include []string          `yaml:"include"`
+	Exclude []string          `yaml:"exclude"`
 }
 
 type OutputType string

--- a/internal/output/dotenv.go
+++ b/internal/output/dotenv.go
@@ -4,20 +4,18 @@ import (
 	"fmt"
 	"io"
 	"strings"
-
-	"github.com/dotnetmentor/racoon/internal/config"
 )
 
-func Dotenv(w io.Writer, m config.Manifest, keys map[string]string, values map[string]string) {
-	for _, s := range m.Secrets {
+func Dotenv(w io.Writer, secrets []string, remap map[string]string, values map[string]string) {
+	for _, s := range secrets {
 		var key string
-		if remapped, ok := keys[s.Name]; ok && remapped != "" {
+		if remapped, ok := remap[s]; ok && remapped != "" {
 			key = remapped
 		} else {
-			key = CamelCaseSplitToUpperJoinByUnderscore(s.Name)
+			key = CamelCaseSplitToUpperJoinByUnderscore(s)
 		}
 
-		value := strings.TrimSuffix(values[s.Name], "\n")
+		value := strings.TrimSuffix(values[s], "\n")
 		w.Write([]byte(fmt.Sprintf("%s=\"%s\"\n", key, value)))
 	}
 }

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -4,21 +4,19 @@ import (
 	"encoding/json"
 	"io"
 	"strings"
-
-	"github.com/dotnetmentor/racoon/internal/config"
 )
 
-func Json(w io.Writer, m config.Manifest, keys map[string]string, values map[string]string) {
+func Json(w io.Writer, secrets []string, remap map[string]string, values map[string]string) {
 	jo := map[string]string{}
-	for _, s := range m.Secrets {
+	for _, s := range secrets {
 		var key string
-		if remapped, ok := keys[s.Name]; ok && remapped != "" {
+		if remapped, ok := remap[s]; ok && remapped != "" {
 			key = remapped
 		} else {
-			key = s.Name
+			key = s
 		}
 
-		value := strings.TrimSuffix(values[s.Name], "\n")
+		value := strings.TrimSuffix(values[s], "\n")
 		jo[key] = value
 	}
 	json.NewEncoder(w).Encode(jo)

--- a/internal/output/tfvars.go
+++ b/internal/output/tfvars.go
@@ -4,20 +4,18 @@ import (
 	"fmt"
 	"io"
 	"strings"
-
-	"github.com/dotnetmentor/racoon/internal/config"
 )
 
-func Tfvars(w io.Writer, m config.Manifest, keys map[string]string, values map[string]string) {
-	for _, s := range m.Secrets {
+func Tfvars(w io.Writer, secrets []string, remap map[string]string, values map[string]string) {
+	for _, s := range secrets {
 		var key string
-		if remapped, ok := keys[s.Name]; ok && remapped != "" {
+		if remapped, ok := remap[s]; ok && remapped != "" {
 			key = remapped
 		} else {
-			key = CamelCaseSplitToLowerJoinByUnderscore(s.Name)
+			key = CamelCaseSplitToLowerJoinByUnderscore(s)
 		}
 
-		value := strings.TrimSuffix(values[s.Name], "\n")
+		value := strings.TrimSuffix(values[s], "\n")
 		w.Write([]byte(fmt.Sprintf("%s = \"%s\"\n", key, value)))
 	}
 }

--- a/internal/utils/environment.go
+++ b/internal/utils/environment.go
@@ -9,12 +9,3 @@ func StringEnvVar(key, defaultValue string) string {
 	}
 	return defaultValue
 }
-
-func StringSliceContains(slice []string, str string) bool {
-	for _, s := range slice {
-		if s == str {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/utils/environment.go
+++ b/internal/utils/environment.go
@@ -9,3 +9,12 @@ func StringEnvVar(key, defaultValue string) string {
 	}
 	return defaultValue
 }
+
+func StringSliceContains(slice []string, str string) bool {
+	for _, s := range slice {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/utils/slice.go
+++ b/internal/utils/slice.go
@@ -1,0 +1,10 @@
+package utils
+
+func StringSliceContains(slice []string, str string) bool {
+	for _, s := range slice {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
NOTE: This builds upon #4 that must be merged before this PR.

Adds support for including or excluding specific secrets using the export command.
1)  Flags --include (-i) and --exclude (-e) may be used to filter secrets for export. Multiple flags may be used to include or exclude multiple secrets.
2) Output includes and excludes may be specified in the manifest file. These only apply to the output where they are specified.

Here's an example manifest, excluding MongodbConnection and DefaultSender when exporting using the dotenv output
```
secrets:
  - name: MongodbConnection
  - name: TwilioAccountSid
  - name: TwilioAuthToken
  - name: TwilioServiceId
  - name: DefaultSender
outputs:
  - type: dotenv
    path: output/.env
    exclude:
      - MongodbConnection
      - DefaultSender
```